### PR TITLE
better logging for component startup test

### DIFF
--- a/src/disco_app.erl
+++ b/src/disco_app.erl
@@ -57,7 +57,10 @@ start(_StartType, _StartArgs) ->
             StartupResults =
                 case DoStartupTest of
                     true ->
-                        utils:pmap(fun(Prog) -> port_utils:try_open("", Prog, TestTimeout) end,
+                        utils:pmap(fun(Prog) ->
+                                       ok = lager:info("Testing ~s", [Prog]),
+                                       port_utils:try_open("", Prog, TestTimeout)
+                                   end,
                                    [BarkeeperProg, ValidatorProg, ChangerProg] ++ GuiProgList);
                     false ->
                         []


### PR DESCRIPTION
I've had problems getting disco to start on a fresh fedora installation. I used this additional logging to find out that I was missing the `PyQt4-devel` and I think it is generally useful.